### PR TITLE
add full_seq for multi-line FASTA support

### DIFF
--- a/src/record.rs
+++ b/src/record.rs
@@ -1,7 +1,11 @@
+use std::borrow::Cow;
+
 pub trait MinimalRefRecord<'a> {
     fn ref_head(&self) -> &[u8];
 
     fn ref_seq(&self) -> &[u8];
+
+    fn ref_full_seq(&self) -> Cow<[u8]>;
 
     fn ref_qual(&self) -> &[u8];
 }
@@ -13,6 +17,10 @@ impl MinimalRefRecord<'_> for seq_io::fastq::RefRecord<'_> {
 
     fn ref_seq(&self) -> &[u8] {
         <Self as seq_io::fastq::Record>::seq(self)
+    }
+
+    fn ref_full_seq(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self.ref_seq())
     }
 
     fn ref_qual(&self) -> &[u8] {
@@ -27,6 +35,10 @@ impl MinimalRefRecord<'_> for seq_io::fasta::RefRecord<'_> {
 
     fn ref_seq(&self) -> &[u8] {
         <Self as seq_io::fasta::Record>::seq(self)
+    }
+
+    fn ref_full_seq(&self) -> Cow<[u8]> {
+        self.full_seq()
     }
 
     fn ref_qual(&self) -> &[u8] {


### PR DESCRIPTION
Hi there, I really like the improved flexibility + ergonomics of concurrency in `seq_io_parallel` over `seq_io`; thanks for developing this!

One thing I noticed is that `seq_io_parallel` doesn't support multi-line FASTA yet (but `seq_io` does with the `full_seq()` method).

This PR exposes that method. I went about it in a very naive way and added it to the trait (even though it's only defined for FASTA records and not FASTQ records in `seq_io`). Feel free to implement this another way (or outright just decline the PR).